### PR TITLE
show image at the top

### DIFF
--- a/lost-cruz/app/createPost/page.js
+++ b/lost-cruz/app/createPost/page.js
@@ -167,6 +167,8 @@ const CreatePost = () => {
         display: "flex",
         flexDirection: "column",
         bgcolor: "#FCF7ED",
+        width: "100vw",
+        position: "absolute",
       }}
     >
       {/* close + send */}

--- a/lost-cruz/app/forum/[postId]/page.js
+++ b/lost-cruz/app/forum/[postId]/page.js
@@ -489,6 +489,7 @@ const PostPage = ({ params }) => {
                     width: "300px",
                     height: "auto",
                     marginLeft: "5px",
+                    alignSelf: 'start',
                   }}
                 >
                   {imageUrl ? (


### PR DESCRIPTION
show image at the top instead of the middle on the post page